### PR TITLE
fix: improve timestamp parsing

### DIFF
--- a/src/data_collection/log_parser.py
+++ b/src/data_collection/log_parser.py
@@ -218,10 +218,16 @@ class LogParser:
             
             for fmt in formats:
                 try:
-                    dt = datetime.strptime(timestamp_str.split()[0], fmt)
+                    # Try parsing the entire timestamp first to preserve information
+                    dt = datetime.strptime(timestamp_str, fmt)
                     return dt.isoformat()
                 except ValueError:
-                    continue
+                    try:
+                        # Some logs may include extra data after a space; fall back to the first token
+                        dt = datetime.strptime(timestamp_str.split()[0], fmt)
+                        return dt.isoformat()
+                    except ValueError:
+                        continue
             
             # If no format matches, return current time
             return datetime.now().isoformat()

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,28 @@
+"""Tests for LogParser timestamp parsing"""
+
+from datetime import datetime
+import sys
+import types
+from pathlib import Path
+
+# Provide a minimal stub for pandas to avoid heavy dependency during tests
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+# Minimal stub for yaml used by configuration loading
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *args, **kwargs: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+# Ensure src package is importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.data_collection.log_parser import LogParser
+
+
+def test_parse_timestamp_with_timezone():
+    parser = LogParser()
+    ts = "10/Oct/2000:13:55:36 -0700"
+    expected = datetime.strptime(ts, "%d/%b/%Y:%H:%M:%S %z").isoformat()
+    assert parser._parse_timestamp(ts) == expected
+


### PR DESCRIPTION
## Summary
- handle timezone-aware timestamps in log parsing
- add tests for timestamp parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa71027cbc832585d80c79bc6c9a7f